### PR TITLE
implement volunteer heatmap

### DIFF
--- a/routes/volunteers/volunteers.js
+++ b/routes/volunteers/volunteers.js
@@ -235,21 +235,21 @@ volunteerRouter.get('/events/:eventId', async (req, res) => {
 });
 
 // get available volunteers at specific date and time
-// volunteerRouter.get('/available/day/:day/start/:startTime/end/:endTime', async (req, res) => {
-//   try {
-//     const day = req.params.day.toLowerCase();
-//     const endTime = req.params.endTime.replace('-', ':');
-//     const startTime = req.params.startTime.replace('-', ':');
-//     // assume startTime and endTime is a timestamp
-//     const volunteers = await pool.query(
-//       'SELECT u.name FROM availability a INNER JOIN "users" u on u.id = a.user_id WHERE day_of_week = $1 and start_time = $2 and end_time = $3',
-//       [day, `${startTime}PST`, `${endTime}PST`],
-//     );
-//     res.status(200).json(volunteers.rows);
-//   } catch (err) {
-//     res.status(500).json(err);
-//   }
-// });
+volunteerRouter.get('/available/day/:day/start/:startTime/end/:endTime', async (req, res) => {
+  try {
+    const { day } = req.params;
+    const endTime = req.params.endTime.replace('-', ':');
+    const startTime = req.params.startTime.replace('-', ':');
+    // assume startTime and endTime is a timestamp
+    const volunteers = await pool.query(
+      'SELECT users.user_id, users.first_name, users.last_name FROM availability INNER JOIN users on users.user_id = availability.user_id WHERE availability.day_of_week = $1 and availability.start_time = $2 and availability.end_time = $3',
+      [day, `${startTime}PST`, `${endTime}PST`],
+    );
+    res.status(200).json(volunteers.rows);
+  } catch (err) {
+    res.status(500).json(err);
+  }
+});
 
 // get number of volunteers at specific event
 // volunteerRouter.get('/:eventId', async (req, res) => {

--- a/routes/volunteers/volunteers.js
+++ b/routes/volunteers/volunteers.js
@@ -30,14 +30,18 @@ volunteerRouter.get('/', async (req, res) => {
     };
     const eventCondition = eventOptions[eventInterest];
 
+    const driverQuery = driverCondition ? ` AND  ${driverCondition}` : '';
+    const ageQuery = ageCondition ? ` AND  ${ageCondition}` : '';
+    const eventQuery = eventCondition ? ` AND  ${eventCondition}` : '';
+
     const query = `SELECT users.*, availability.availabilities
     FROM users
       LEFT JOIN
         (SELECT user_id, array_agg(to_jsonb(availability.*) - 'user_id' ORDER BY availability.day_of_week) AS availabilities
           FROM availability
           GROUP BY user_id) AS availability on availability.user_id = users.user_id
-    WHERE users.role = 'volunteer' AND ${driverCondition} AND ${ageCondition} AND ${eventCondition}
-    ORDER BY users.first_name, users.last_name`;
+    WHERE users.role = 'volunteer' ${driverQuery} ${ageQuery} ${eventQuery}
+    ORDER BY users.first_name, users.last_name`; // issue with undefined driverCondition & eventCondition
 
     const { rows: volunteers } = await pool.query(query);
     if (searchQuery) {
@@ -90,6 +94,9 @@ volunteerRouter.get('/available', async (req, res) => {
     const eventCondition = eventOptions[eventInterest];
 
     const resData = {};
+
+    const driverQuery = driverCondition ? ` AND  ${driverCondition}` : '';
+    const eventQuery = eventCondition ? ` AND  ${eventCondition}` : '';
     // assume startTime and endTime is a timestamp
     const { rows: volunteers } = await pool.query(
       `SELECT
@@ -103,7 +110,7 @@ volunteerRouter.get('/available', async (req, res) => {
         users.can_drive
       FROM users
       INNER JOIN availability
-      ON users.user_id = availability.user_id AND ${driverCondition} AND ${eventCondition}`,
+      ON users.user_id = availability.user_id ${driverQuery} ${eventQuery}`, // issue with undefined driverCondition & eventCondition
       [],
     );
 


### PR DESCRIPTION
### What changes are included in this PR?

#### Heatmap
- Refactored a lot of smelly code
- Formatted heatmap to actually use backend info (the original issue was that keys weren't properly capitalized)

#### Backend Routes
- Both /volunteers and /volunteers/available were broken because of new payload params not being optional, fixed now

#### Volunteer Availability
- Grabbed volunteer list from backend

### Instructions to test changes:
#### Heatmap
- Cross reference the heatmap numbers with backend tables
- Double check the time formats are correct and properly ordered

#### Backend Routes
- Test /volunteers and /volunteers/available so that they still work with and without the new payload params

#### Volunteer Availability
- Cross reference the volunteer list with backend tables

### Images
![Screenshot 2022-09-23 231051](https://user-images.githubusercontent.com/66648948/192082908-48056d3b-2ce8-4f2f-8a95-d88b92b7f1c1.png)

### Todo
- Heatmap currently is one indexed, so timeslots that have no volunteer availability are set to 1 instead of 0, and everything else is incremented by 1 as well (motivation is that the chart doesn't show the timeslot square without a nonzero value)
- Nothing on that page is interactable other than the chart and the "View Database" button, not sure if that's by design

closes #104